### PR TITLE
Updates to response processing and analysis DB

### DIFF
--- a/allensdk/brain_observatory/behavior/behavior_project_api/behavior_ophys_analysis_query_utils.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_api/behavior_ophys_analysis_query_utils.py
@@ -187,8 +187,10 @@ def write_stimulus_response_to_collection(session, server='visual_behavior_data'
     res = vb['ophys_data']['stimulus_response'].find_one(
         {'ophys_experiment_id': int(session.ophys_experiment_id)})
     if res is None:
-        df = session.get_stimulus_response_df().drop(
-            ['dff_trace', 'dff_trace_timestamps'], axis=1)
+
+        df = session.stimulus_response_df.drop(columns=['dff_trace', 'dff_trace_timestamps']).merge(session.stimulus_presentations['image_name'], 
+                                                                                                    left_on='stimulus_presentations_id', 
+                                                                                                    right_index=True)
         for idx, row in df.reset_index().iterrows():
             entry = {'ophys_experiment_id': int(session.ophys_experiment_id)}
             entry.update(row.to_dict())

--- a/allensdk/brain_observatory/behavior/behavior_project_api/behavior_ophys_analysis_query_utils.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_api/behavior_ophys_analysis_query_utils.py
@@ -199,6 +199,14 @@ def write_stimulus_response_to_collection(session, server='visual_behavior_data'
 #         print('experiment {} already in table'.format(session.ophys_experiment_id))
     vb.close()
 
+def write_eventlocked_traces_to_collection(session, server='visual_behavior_data'):
+    stacked_trace = session.stimulus_response_xr['eventlocked_traces'].stack(multi_index=('cell_specimen_id', 'stimulus_presentations_id', 'eventlocked_timestamps'))
+    df_stack = stacked_trace.to_dataframe()
+    df_pivot = df_stack.pivot_table(values='eventlocked_traces',
+                                    index=('stimulus_presentations_id', 'eventlocked_timestamps'),
+                                    columns='cell_specimen_id')
+
+
 
 def get_stimulus_response(query=None, server='visual_behavior_data'):
     '''
@@ -249,7 +257,7 @@ def write_stimulus_presentations_to_collection(session, server='visual_behavior_
 
     #  if res is None:
     if True:
-        df = session.stimulus_presentations.drop(
+        df = session.extended_stimulus_presentations.drop(
             ['licks', 'rewards'], axis=1).reset_index()
 
         entry = {'ophys_experiment_id': int(session.ophys_experiment_id)}

--- a/allensdk/brain_observatory/behavior/response_processing.py
+++ b/allensdk/brain_observatory/behavior/response_processing.py
@@ -172,7 +172,7 @@ def stimulus_response_xr(session, response_analysis_params=None):
     )
 
     response_range = [0, response_analysis_params['response_window_duration_seconds']]
-    baseline_range = [-1*response_analysis_params['baseline_window_duration_seconds']]
+    baseline_range = [-1*response_analysis_params['baseline_window_duration_seconds'], 0]
 
     mean_response = eventlocked_traces_xr.loc[
         {'eventlocked_timestamps':slice(*response_range)}
@@ -198,7 +198,7 @@ def stimulus_response_xr(session, response_analysis_params=None):
     result = result.merge(session.stimulus_presentations[['image_index', 'image_name']])
     mean_response_per_image = result[['mean_response', 'image_index']].groupby('image_index').mean(dim='stimulus_presentations_id')
     image_indices = mean_response_per_image.coords['image_index']
-    pref_image_index = mean_response_per_image['mean_response'].argmax(dim='image_index')
+    pref_image_index = mean_response_per_image.drop(8, dim='image_index')['mean_response'].argmax(dim='image_index') #drop omitted
     result['pref_image_index'] = pref_image_index
     result['pref_image_bool'] = result['image_index'] == result['pref_image_index']
 


### PR DESCRIPTION
This fixes a bug that was causing the baseline response to be NaN, and drops the 'omitted' stimuli from consideration when calculating the preferred stimulus in the response processing module. Also includes updates the the analysis database module for uploading the eventlocked traces, and switches from uploading the regular stimulus presentations table to the extended one which has a lot of useful information. 